### PR TITLE
Provide Enhancements to docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,8 @@ To start the services, run `docker-compose up -d`.
 TODO 
 
 Steps to generate a topology from the archetypes
-Launch a topology + run it on the cluster
+Launch a topology ( (1) via Flux (2) via Java) + run it on the cluster
+  - (a) Inject seeds
+  - (b) Run crawl
+
+If elasticsearch / kibana: Explain how to create index + mappings (or link to documentation)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,4 @@ To start the services, run `docker-compose up -d`.
 TODO 
 
 Steps to generate a topology from the archetypes
-Launch a topology ( (1) via Flux (2) via Java) + run it on the cluster
-  - (a) Inject seeds
-  - (b) Run crawl
-
-If elasticsearch / kibana: Explain how to create index + mappings (or link to documentation)
+Launch a topology via Flux + run it on the cluster

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   zookeeper:
-    image: zookeeper
+    image: zookeeper:3.7.0
     container_name: zookeeper
     restart: always
 
@@ -11,7 +11,7 @@ services:
 #    container_name: frontier
 #    command: rocksdb.path=/crawldir/rocksdb
 #    ports:
-#      - 7071:7071
+#      - "127.0.0.1:7071:7071"
 #    volumes:
 #      - data01:/crawldir
 
@@ -19,13 +19,13 @@ services:
 #    image: prom/prometheus 
 #    container_name: prometheus
 #    ports:
-#      - 127.0.0.1:9090:9090
+#      - "127.0.0.1:9090:9090"
 
 #  grafana:
 #    image: grafana/grafana
 #    container_name: grafana
 #    ports:
-#      - 3000:3000
+#      - "127.0.0.1:3000:3000"
 
 #  elastic:
 #    image: docker.elastic.co/elasticsearch/elasticsearch:7.12.1
@@ -41,9 +41,20 @@ services:
 #        soft: -1
 #        hard: -1
 #    ports:
-#      - 9200:9200
+#      - "127.0.0.1:9200:9200"
 #    volumes:
 #      - data02:/usr/share/elasticsearch/data
+#
+#  kibana:
+#    image: kibana:7.12.1
+#    container_name: kibana
+#    environment:
+#      ELASTICSEARCH_URL: http://elastic:9200
+#      ELASTICSEARCH_HOSTS: http://elastic:9200
+#    depends_on:
+#      - elastic
+#    ports:
+#      - "127.0.0.1:5601:5601"
 
   nimbus:
     image: storm
@@ -52,6 +63,8 @@ services:
     depends_on:
       - zookeeper
     restart: always
+    volumes:
+      - storm-nimbus-logs:/logs
 
   supervisor:
     image: storm
@@ -61,6 +74,9 @@ services:
       - nimbus
       - zookeeper
     restart: always
+    volumes:
+      - storm-supervisor-data:/data
+      - storm-supervisor-logs:/logs
 
   ui:
     image: storm
@@ -70,7 +86,9 @@ services:
       - nimbus
     restart: always
     ports:
-      - 8080:8080
+      - "127.0.0.1:8080:8080"
+    volumes:
+      - storm-ui-logs:/logs
 
   logviewer:
     image: storm
@@ -81,11 +99,20 @@ services:
       - supervisor
     restart: always
     ports:
-      - 8000:8000
+      - "127.0.0.1:8000:8000"
 
 volumes:
+  # URL-Frontier
   data01:
     driver: local
+  # Elasticsearch
   data02:
     driver: local
-
+  storm-ui-logs:
+    driver: local
+  storm-nimbus-logs:
+    driver: local
+  storm-supervisor-data:
+    driver: local
+  storm-supervisor-logs:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
 #      - "127.0.0.1:5601:5601"
 
   nimbus:
-    image: storm
+    image: storm:2.3.0
     container_name: nimbus
     command: storm nimbus
     depends_on:
@@ -67,7 +67,7 @@ services:
       - storm-nimbus-logs:/logs
 
   supervisor:
-    image: storm
+    image: storm:2.3.0
     container_name: supervisor
     command: storm supervisor -c worker.childopts=-Xmx%HEAP-MEM%m
     depends_on:
@@ -79,7 +79,7 @@ services:
       - storm-supervisor-logs:/logs
 
   ui:
-    image: storm
+    image: storm:2.3.0
     container_name: ui
     command: storm ui
     depends_on:


### PR DESCRIPTION
# What does this PR do?

- Adds explicit version number for zookeeper
  - We should better stick to a version, which is safe / stable to use with Storm.
- Adds explicit version number for storm
  - see above (better to be conservative here, sometimes `latest` might break things...)
- Adds explicit localhost port mappings 
  - avoid firewall issues
  -  better for security, if users run it on VM infrastructure)
- Adds kibana image and configures it for usage with elastic
  - in case some one uses it for this use-case
- Adds volumes for log / data directories of storm supervisors, nimbus, etc 
  - From my experiments with Java 17 I know, that it is sometimes required to check for problems directly if logviewer does not come up, etc. - addtional volumes shouldn't hurt too much.
- Updates README with some additional thoughts / todos

## Additional Thoughts

We could also split the `docker-compose.yml` for the different use-cases, i.e elastic / kibana ; url-frontier ; etc.
It would just change to `docker-compose up -d -f <file>`.